### PR TITLE
Fix PLATFORM_RELATIONSHIPS variable appearing as empty when relations…

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -71,7 +71,7 @@ applications:
                     passthru: true
 
 #        relationships:
-#            redis-session: "redis_persistent:redis-persistent"
+#            redis-session: "redis_persistent:redis"
 
 # Managed services configuration.
 #services:


### PR DESCRIPTION
Ensure `PLATFORM_RELATIONSHIPS` populates a relationship when redis relationship is enabled