### PR TITLE
17 replace glowing background redis svg with non glowing background svg

### DIFF
--- a/frontend/src/assets/utility/service_redis.svg
+++ b/frontend/src/assets/utility/service_redis.svg
@@ -11,16 +11,4 @@
     <path d="M25.6299 23.3281L28.9199 24.6281L25.6299 25.9281V23.3281Z" fill="#7A0C00"/>
     <path d="M22.0195 24.7781L25.6495 23.3281V25.9281L25.2895 26.0781L22.0195 24.7781Z" fill="#AD2115"/>
   </g>
-  <defs>
-    <filter id="filter0_d_660_8787" x="-20" y="-10" width="80" height="80" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-      <feOffset/>
-      <feGaussianBlur stdDeviation="10"/>
-      <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.847059 0 0 0 0 0.172549 0 0 0 0 0.12549 0 0 0 1 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_660_8787"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_660_8787" result="shape"/>
-    </filter>
-  </defs>
 </svg>


### PR DESCRIPTION
Replaces the redis icon with one that does not have a glowing bg—providing better rendering as the edges are not cut off.