### PR TITLE
Handle default resources

### DIFF
--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -192,27 +192,19 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |    
                 ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push state complete "first_push"  
-            - name: "[first_deploy] 3. Test: The first deploy activity should fail."
+            - name: "[first_deploy] 3. Test: The first deploy activity should succeed."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
-                ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push result failure "first_push"
-
-            ################################################################################################
-            # F. Set initial resources.
-            - name: "[init_resources] 1. Set initial resources."
-              working-directory: ${{ env.PROJECT_LOCALDIR }}
-              run: |
-                  cmd=$(cat frontend/src/commands.json | jq -r ".first_deploy.user.resources_set") 
-                  eval "$cmd"
-            - name: "[init_resources] 2. Test: The update environment resources activity should complete."
+                ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push result success "first_push"
+            - name: "[first_deploy] 4. Test: The update environment resources activity should complete."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update state complete "init_resources"
-            - name: "[init_resources] 3. Test: The update environment resources activity should succeed."
+            - name: "[first_deploy] 5. Test: The update environment resources activity should succeed."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update result success "init_resources"
-            - name: "[init_resources] 4. Test: Updating environment resources should result in a 200 on the frontend production app."
+            - name: "[first_deploy] 6. Test: Updating environment resources should result in a 200 on the frontend production app."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED_STATUS="200"
@@ -220,8 +212,7 @@ jobs:
                   eval "$cmd"
                   PROD_URL_FRONTEND=$(eval "$cmd --pipe")
                   ./utils/tests/url_status.sh $PROD_URL_FRONTEND $EXPECTED_STATUS "production frontend deployment (init_resources)"
-
-            - name: "[init_resources] 5. Test: Updating environment resources should result in a 200 on the backend production app."
+            - name: "[first_deploy] 7. Test: Updating environment resources should result in a 200 on the backend production app."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED_STATUS="200"
@@ -235,7 +226,7 @@ jobs:
                   # Data path
                   PROD_URL_BACKEND=$PROD_URL_FRONTEND$BACKEND_PATH
                   ./utils/tests/url_status.sh $PROD_URL_BACKEND $EXPECTED_STATUS "production backend deployment (init_resources)"
-            - name: "[init_resources]  6. Test: endpoint data (session_storage)"
+            - name: "[first_deploy] 8. Test: endpoint data (session_storage)"
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED="file"
@@ -245,7 +236,7 @@ jobs:
                   PROD_URL_BACKEND=$PROD_URL_FRONTEND$BACKEND_PATH
                   RESULT=$(curl -s $PROD_URL_BACKEND | jq -r '.session_storage')
                   ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "PROD Backend data session_storage"
-            - name: "[init_resources] 7. Test: endpoint data (environment_type)"
+            - name: "[first_deploy] 9. Test: endpoint data (environment_type)"
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED="production"
@@ -255,7 +246,7 @@ jobs:
                   PROD_URL_BACKEND=$PROD_URL_FRONTEND$BACKEND_PATH
                   RESULT=$(curl -s $PROD_URL_BACKEND | jq -r '.type')
                   ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "PROD Backend data environment_type"
-            - name: "[init_resources] 8. Test: backend base path"
+            - name: "[first_deploy] 10. Test: backend base path"
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED="Hello from the Python backend!"
@@ -345,34 +336,25 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |    
                 ./utils/tests/activity_outcome.sh $STAGING_BRANCH push state complete "add_service"  
-            - name: "[add_service] 3. Test: The add_service activity should fail."
+            - name: "[add_service] 3. Test: The add_service activity should succeed."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
-                ./utils/tests/activity_outcome.sh $STAGING_BRANCH push result failure "add_service"
-                
-            ################################################################################################
-            # I. Define service resources.
-            - name: "[add_service_resources] 1. Set Redis' resources."
-              working-directory: ${{ env.PROJECT_LOCALDIR }}
-              run: |
-                  upsun resources:set --size redis_persistent:0.1 --disk redis_persistent:512
-                  cmd=$(cat frontend/src/commands.json | jq -r ".redis.user.resources_set") 
-                  eval "$cmd"
-            - name: "[add_service_resources] 2. Test: The add_service_resources activity should complete."     
+                ./utils/tests/activity_outcome.sh $STAGING_BRANCH push result success "add_service"
+            - name: "[add_service] 4. Test: The add_service_resources activity should complete."     
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   ./utils/tests/activity_outcome.sh $STAGING_BRANCH environment.resources.update state complete "add_service_resources"
-            - name: "[add_service_resources] 3. Test: The update environment resources activity should succeed."        
+            - name: "[add_service] 5. Test: The update environment resources activity should succeed."        
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   ./utils/tests/activity_outcome.sh $STAGING_BRANCH environment.resources.update result success "add_service_resources"
-            - name: "[add_service_resources] 4. Test: The update environment resources activity should result in a 200 on the frontend staging app." 
+            - name: "[add_service] 6. Test: The update environment resources activity should result in a 200 on the frontend staging app." 
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED_STATUS="200"
                   STAG_URL_FRONTEND=$(upsun url --primary --pipe)
                   ./utils/tests/url_status.sh $STAG_URL_FRONTEND $EXPECTED_STATUS "staging frontend deployment (add_service_resources)"
-            - name: "[add_service_resources] 5. Test: The update environment resources activity should result in a 200 on the backend staging app."
+            - name: "[add_service] 7. Test: The update environment resources activity should result in a 200 on the backend staging app."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED_STATUS="200"
@@ -384,7 +366,7 @@ jobs:
                   # Data path 
                   STAG_URL_BACKEND=$STAG_URL_FRONTEND$BACKEND_PATH
                   ./utils/tests/url_status.sh $STAG_URL_BACKEND $EXPECTED_STATUS "staging backend deployment (add_service_resources)"
-            - name: "[add_service_resources] 6. Test: endpoint data (session_storage)"  
+            - name: "[add_service] 8. Test: endpoint data (session_storage)"  
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED="redis"
@@ -392,7 +374,7 @@ jobs:
                   STAG_URL_BACKEND=$STAG_URL_FRONTEND$BACKEND_PATH
                   RESULT=$(curl -s $STAG_URL_BACKEND | jq -r '.session_storage')
                   ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "STAG Backend data session_storage"
-            - name: "[add_service_resources] 7. Test: endpoint data (environment_type)"
+            - name: "[add_service] 9. Test: endpoint data (environment_type)"
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED="staging"
@@ -400,7 +382,7 @@ jobs:
                   STAG_URL_BACKEND=$STAG_URL_FRONTEND$BACKEND_PATH
                   RESULT=$(curl -s $STAG_URL_BACKEND | jq -r '.type')
                   ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "STAG Backend data environment_type"
-            - name: "[add_service_resources] 8. Test: backend base path"
+            - name: "[add_service] 10. Test: backend base path"
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED="Hello from the Python backend!"
@@ -421,34 +403,25 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |    
                 ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push state complete "merge"  
-            - name: "[merge] 3. Test: The merge activity should fail."
+            - name: "[merge] 3. Test: The merge activity should succeed."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
-                ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push result failure "merge"
-                
-            ################################################################################################
-            # J. Define production service resources.
-            - name: "[prod_service_resources] 1. Set Redis' resources on production."
-              working-directory: ${{ env.PROJECT_LOCALDIR }}
-              run: |
-                  # upsun resources:set --size redis_persistent:0.1 --disk redis_persistent:512 -e $DEFAULT_BRANCH
-                  cmd=$(cat frontend/src/commands.json | jq -r ".merge_production.test.resources_set") 
-                  eval "$cmd"
-            - name: "[prod_service_resources] 2. Test: The update environment resources activity should complete."
+                ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push result success "merge"
+            - name: "[merge] 4. Test: The update environment resources activity should complete."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update state complete "init_resources"
-            - name: "[prod_service_resources] 3. Test: The update environment resources activity should succeed."
+            - name: "[merge] 5. Test: The update environment resources activity should succeed."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update result success "init_resources"
-            - name: "[prod_service_resources] 4. Test: Updating environment resources should result in a 200 on the frontend production app."
+            - name: "[merge] 6. Test: Updating environment resources should result in a 200 on the frontend production app."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED_STATUS="200"
                   PROD_URL_FRONTEND=$(upsun url --primary --pipe)
                   ./utils/tests/url_status.sh $PROD_URL_FRONTEND $EXPECTED_STATUS "production frontend deployment (init_resources)"
-            - name: "[prod_service_resources] 5. Test: Updating environment resources should result in a 200 on the backend production app."
+            - name: "[merge] 7. Test: Updating environment resources should result in a 200 on the backend production app."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED_STATUS="200"
@@ -460,7 +433,7 @@ jobs:
                   # Data path 
                   PROD_URL_BACKEND=$PROD_URL_FRONTEND$BACKEND_PATH
                   ./utils/tests/url_status.sh $PROD_URL_BACKEND $EXPECTED_STATUS "production backend deployment (init_resources)"
-            - name: "[prod_service_resources]  6. Test: endpoint data (session_storage)"
+            - name: "[merge] 8. Test: endpoint data (session_storage)"
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED="redis"
@@ -468,7 +441,7 @@ jobs:
                   PROD_URL_BACKEND=$PROD_URL_FRONTEND$BACKEND_PATH
                   RESULT=$(curl -s $PROD_URL_BACKEND | jq -r '.session_storage')
                   ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "PROD Backend data session_storage"
-            - name: "[prod_service_resources] 7. Test: endpoint data (environment_type)"
+            - name: "[merge] 9. Test: endpoint data (environment_type)"
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED="production"
@@ -476,7 +449,7 @@ jobs:
                   PROD_URL_BACKEND=$PROD_URL_FRONTEND$BACKEND_PATH
                   RESULT=$(curl -s $PROD_URL_BACKEND | jq -r '.type')
                   ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "PROD Backend data environment_type"
-            - name: "[prod_service_resources] 8. Test: backend base path"
+            - name: "[merge] 10. Test: backend base path"
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   EXPECTED="Hello from the Python backend!"
@@ -485,8 +458,68 @@ jobs:
                   PROD_URL_BACKEND=$PROD_URL_FRONTEND$BASE_PATH
                   RESULT=$(curl -s $PROD_URL_BACKEND)
                   ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "PROD Backend data environment_type"
+
             ################################################################################################
-            # K. Clean up test project.
+            # L. Scale down to minimum resources
+            - name: "[scale] 1. Scale down to minimum resources for Redis"
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  cmd=$(cat frontend/src/commands.json | jq -r ".scale.test.resources_set") 
+                  eval "$cmd"
+            - name: "[scale] 2. Test: The update environment resources activity should complete."
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update state complete "init_resources"
+            - name: "[scale] 3. Test: The update environment resources activity should succeed."
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update result success "init_resources"
+            - name: "[scale] 4. Test: Updating environment resources should result in a 200 on the frontend production app."
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  EXPECTED_STATUS="200"
+                  PROD_URL_FRONTEND=$(upsun url --primary --pipe)
+                  ./utils/tests/url_status.sh $PROD_URL_FRONTEND $EXPECTED_STATUS "production frontend deployment (init_resources)"
+            - name: "[scale] 5. Test: Updating environment resources should result in a 200 on the backend production app."
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  EXPECTED_STATUS="200"
+                  PROD_URL_FRONTEND=$(upsun url --primary --pipe)
+                  # Base path
+                  BASE_PATH="api/"
+                  PROD_URL_BACKEND=$PROD_URL_FRONTEND$BASE_PATH
+                  ./utils/tests/url_status.sh $PROD_URL_BACKEND $EXPECTED_STATUS "production backend deployment (init_resources)"              
+                  # Data path 
+                  PROD_URL_BACKEND=$PROD_URL_FRONTEND$BACKEND_PATH
+                  ./utils/tests/url_status.sh $PROD_URL_BACKEND $EXPECTED_STATUS "production backend deployment (init_resources)"
+            - name: "[scale] 6. Test: endpoint data (session_storage)"
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  EXPECTED="redis"
+                  PROD_URL_FRONTEND=$(upsun url --primary --pipe)
+                  PROD_URL_BACKEND=$PROD_URL_FRONTEND$BACKEND_PATH
+                  RESULT=$(curl -s $PROD_URL_BACKEND | jq -r '.session_storage')
+                  ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "PROD Backend data session_storage"
+            - name: "[scale] 7. Test: endpoint data (environment_type)"
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  EXPECTED="production"
+                  PROD_URL_FRONTEND=$(upsun url --primary --pipe)
+                  PROD_URL_BACKEND=$PROD_URL_FRONTEND$BACKEND_PATH
+                  RESULT=$(curl -s $PROD_URL_BACKEND | jq -r '.type')
+                  ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "PROD Backend data environment_type"
+            - name: "[scale] 8. Test: backend base path"
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  EXPECTED="Hello from the Python backend!"
+                  PROD_URL_FRONTEND=$(upsun url --primary --pipe)
+                  BASE_PATH="api/"
+                  PROD_URL_BACKEND=$PROD_URL_FRONTEND$BASE_PATH
+                  RESULT=$(curl -s $PROD_URL_BACKEND)
+                  ./$TEST_PATH/compare_strings.sh "$RESULT" "$EXPECTED" "PROD Backend data environment_type"
+
+            ################################################################################################
+            # L. Clean up test project.
             - name: "[cleanup] 1. Delete project."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -12,7 +12,7 @@ env:
     UPSUN_CLI_NO_INTERACTION: 1
     UPSUN_CLI_TOKEN: ${{secrets.DEVREL_USER_UPSUN_TOKEN}}
 
-    UPSUN_HOST_REGION: "ca-1"
+    UPSUN_HOST_REGION: "eu-3"
     UPSUN_HOST_SUFFIX: "platform.sh"
     UPSUN_USERNAME: "devrel-projects"
 

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -12,7 +12,7 @@ env:
     UPSUN_CLI_NO_INTERACTION: 1
     UPSUN_CLI_TOKEN: ${{secrets.DEVREL_USER_UPSUN_TOKEN}}
 
-    UPSUN_HOST_REGION: "eu-3"
+    UPSUN_HOST_REGION: "ca-1"
     UPSUN_HOST_SUFFIX: "platform.sh"
     UPSUN_USERNAME: "devrel-projects"
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -174,7 +174,6 @@ services:
                         <li className="mt-2 ml-6">Cloned the demo: <code className="ml-2 px-4">{commands.first_deploy.user.clone}</code></li>
                         <li className="mt-2 ml-6">Connected to Upsun: <code className="ml-2 px-4">{commands.first_deploy.user.set_remote} {PROJECT_ID}</code></li>
                         <li className="mt-2 ml-6">Pushed to Upsun: <code className="ml-2 px-4">{commands.first_deploy.user.push}</code></li>
-                        <li className="mt-2 ml-6">Defined deployment resources: <code className="ml-2 px-4">{commands.first_deploy.user.resources_set}</code></li>
                         <li className="mt-2 ml-6">Retrieved the deployed environment URL: <code className="ml-2 px-4">{commands.first_deploy.user.get_url}</code></li>
                       </ul>
                     </div>
@@ -299,25 +298,6 @@ services:
                           </CopyButton>
                         </p>
                       </li>
-                      <li>
-                        <p className="mb-2 mt-2">
-                          <span>Allocate Redis resources</span>
-                          <CopyButton className="pl-1 inline-block w-full" copyText={commands.redis.user.push}>
-                            <p className="mb-2 mt-2 code-block">
-                              <CodeBlock
-                                text={commands.redis.user.resources_set}
-                                showLineNumbers={false}
-                                theme={dracula}
-                              />
-                            </p>
-                          </CopyButton>
-                        </p>
-                      </li>
-                      <li>
-                        <p className="mb-2 mt-2">
-                          <span>Refresh this page when done.</span>
-                        </p>
-                      </li>
                     </ol>
                   </>
                 </FeatureStep>
@@ -361,23 +341,7 @@ services:
                           </CopyButton>
                         </p>
                       </li>
-                      <li>
-                        <p className="mb-2 mt-2">
-                        The previous step will complete, but exit with the message: <span className="text-red-400 font-mono">Resources must be configured before deployment</span>.
-                        </p>
-                        <p className="mb-2 mt-2">
-                          <span>Allocate resources to Redis in production.</span>
-                          <CopyButton className="pl-1 inline-block w-full" copyText={commands["merge_production"].user.resources_set}>
-                            <p className="mb-2 mt-2 code-block">
-                              <CodeBlock
-                                text={commands["merge_production"].user.resources_set}
-                                showLineNumbers={false}
-                                theme={dracula}
-                              />
-                            </p>
-                          </CopyButton>
-                        </p>
-                      </li>
+
                       <li>
                         <p className="mb-2 mt-2">
                           <span>Open production frontend in your browser</span>
@@ -409,6 +373,21 @@ services:
                     <p className="mb-2 mt-2 font-bold">🎉 Kudos! You've aced the Upsun Demo!</p>
                     <p className="mb-2">
                       You've just experienced the power of Upsun's Git-based workflow to stage and deploy Redis seamlessly.
+                    </p>
+                    <p className="mb-2 mt-5">
+                      <span>Upsun automatically allocated a set of default resources for each service in your project, but you can <strong>scale 
+                        those resources</strong> to whatever you need. For example, you can scale down the amount of resources on the
+                        Redis service container with the following command:
+                      </span>
+                      <CopyButton className="pl-1 inline-block w-full" copyText={commands.scale.user.resources_set}>
+                        <p className="mb-2 mt-2 code-block">
+                          <CodeBlock
+                            text={commands.scale.user.resources_set}
+                            showLineNumbers={false}
+                            theme={dracula}
+                          />
+                        </p>
+                      </CopyButton>
                     </p>
                     <p className="mb-2 mt-5">
                       <span>Delete this project when ready using:</span>

--- a/frontend/src/commands.json
+++ b/frontend/src/commands.json
@@ -10,7 +10,6 @@
             "clone": "git clone git@github.com:platformsh/demo-project.git",
             "set_remote": "upsun project:set-remote",
             "push": "upsun push",
-            "resources_set": "upsun resources:set --size '*:0.1'",
             "get_url": "upsun url --primary"
         },
         "test": {
@@ -31,8 +30,7 @@
     "redis": {
         "user": {
             "commit": "git commit -am \"Create a Redis service.\"",
-            "push": "upsun push",
-            "resources_set": "upsun resources:set --size redis_persistent:0.1 --disk redis_persistent:512"
+            "push": "upsun push"
         },
         "test": {
             "push": "git push --force upsun $STAGING_BRANCH"
@@ -41,15 +39,20 @@
     "merge_production": {
         "user": {
             "merge": "upsun merge staging",
-            "resources_set": "upsun resources:set \\\n\t--size redis_persistent:0.1 \\\n\t--disk redis_persistent:512 \\\n\t-e main",
             "get_url": "upsun url --primary -e main"
         },
         "test": {
-            "merge": "git checkout $DEFAULT_BRANCH && git merge $STAGING_BRANCH && git push --force upsun $DEFAULT_BRANCH",
-            "resources_set": "upsun resources:set \\\n\t--size redis_persistent:0.1 \\\n\t--disk redis_persistent:512"
+            "merge": "git checkout $DEFAULT_BRANCH && git merge $STAGING_BRANCH && git push --force upsun $DEFAULT_BRANCH"
         }
     },
-    "scale": false,
+    "scale": {
+        "user": {
+            "resources_set": "upsun resources:set \\\n\t--size redis_persistent:minimum \\\n\t--disk redis_persistent:minimum \\\n\t-e main"
+        },
+        "test": {
+            "merge": "upsun resources:set \\\n\t--size redis_persistent:minimum \\\n\t--disk redis_persistent:minimum \\\n\t-e $DEFAULT_BRANCH"
+        }
+    },
     "complete": {
         "user": {
             "delete_project": "upsun project:delete"

--- a/frontend/src/utility/api.ts
+++ b/frontend/src/utility/api.ts
@@ -23,9 +23,9 @@ export const fetchEnvironment = async (): Promise<EnvironmentResponseType> => {
   // let override_state = "branch";
   // let override_state = "redis";
   // let override_state = "merge-production";
-  // let override_state = "scale";
   // let override_state = "error_state"
   // let override_state = "complete";
+  // let override_state = "scale";
 
   if (BASE_PATH == "http://localhost:8000/") {
 


### PR DESCRIPTION
Git 24 introduces default resources, which remove `resources:set` requirements and change the path slightly. Namely: 

- default resources are set for each push
- resources settings of a child environment are "inherited" by a parent

Closes https://github.com/platformsh/demo-project/issues/60

**Todo**

- [ ] [CLI command strategies needs merging](https://github.com/platformsh/legacy-cli/issues/1340) (`resources:set --size '*:minumum'`)
- [ ] Right now I can’t access eu-3 to test on the current DevRel team user token. Need to sort out that issue, or wait until generally available
- [ ] the starting resources:set command needs removing from console
- [ ] once finished, reset workflow region to `ca-1` from `eu-3`