### PR TITLE
Default resources take 2

### DIFF
--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -203,11 +203,10 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |    
                 ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push state complete "first_push"  
-            - name: "[first_deploy] 3. Test: The update environment resources activity should succeed."
+            - name: "[first_deploy] 3. Test: The first deploy activity should succeed."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
-                  ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update result success "init_resources"
-            
+                  ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push result success "first_push"
             - name: "[first_deploy] X. Test: Test responses on demo app using Blackfire Player."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
@@ -242,7 +241,7 @@ jobs:
                   upsun environment:info title "Staging ($STAGING_BRANCH)" -e $STAGING_BRANCH
 
             ################################################################################################
-            # H. Add a service.
+            # G. Add a service.
             - name: "[add_service] 1. Uncomment service configuration block. Commit & push new service."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
@@ -256,28 +255,10 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |    
                 ./utils/tests/activity_outcome.sh $STAGING_BRANCH push state complete "add_service"  
-            - name: "[add_service] 3. Test: The add_service activity should fail."
+            - name: "[add_service] 3. Test: The add_service activity should succeed."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
-                ./utils/tests/activity_outcome.sh $STAGING_BRANCH push result failure "add_service"
-                
-            ################################################################################################
-            # I. Define service resources.
-            - name: "[add_service_resources] 1. Set Redis' resources."
-              working-directory: ${{ env.PROJECT_LOCALDIR }}
-              run: |
-                  upsun resources:set --size redis_persistent:0.1 --disk redis_persistent:512
-                  cmd=$(cat frontend/src/commands.json | jq -r ".redis.user.resources_set") 
-                  eval "$cmd"
-            - name: "[add_service_resources] 2. Test: The add_service_resources activity should complete."     
-              working-directory: ${{ env.PROJECT_LOCALDIR }}
-              run: |
-                  ./utils/tests/activity_outcome.sh $STAGING_BRANCH environment.resources.update state complete "add_service_resources"
-            - name: "[add_service_resources] 3. Test: The update environment resources activity should succeed."        
-              working-directory: ${{ env.PROJECT_LOCALDIR }}
-              run: |
-                  ./utils/tests/activity_outcome.sh $STAGING_BRANCH environment.resources.update result success "add_service_resources"
-
+                ./utils/tests/activity_outcome.sh $STAGING_BRANCH push result success "add_service"
             - name: "[add_service_resources] X. Test: Test responses on demo app using Blackfire Player."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
@@ -285,7 +266,7 @@ jobs:
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=merge-production -vvv
 
             ################################################################################################
-            # I. Promote revision to production.
+            # H. Promote revision to production.
             - name: "[merge] 1. Merge staging into production."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -303,7 +303,9 @@ jobs:
             - name: "[prod_service_resources] 4. Test: Test responses on demo app using Blackfire Player."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
-                  URL=$(upsun url --primary --pipe)
+                  git checkout $DEFAULT_BRANCH
+                  git branch
+                  URL=$(upsun url -e $DEFAULT_BRANCH --primary --pipe)
                   sleep 2
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=complete -vvv
 

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -321,6 +321,7 @@ jobs:
             - name: "[scale] 4. Test: Test responses on demo app using Blackfire Player."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
+                  git checkout $DEFAULT_BRANCH
                   URL=$(upsun url --primary --pipe)
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=complete -vvv
 

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -276,11 +276,11 @@ jobs:
             - name: "[merge] 2. Test: The merge activity should complete."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |    
-                ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push state complete "merge"  
+                ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.merge state complete "merge"  
             - name: "[merge] 3. Test: The merge activity should fail."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
-                ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push result failure "merge"
+                ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.merge result failure "merge"
                 
             ################################################################################################
             # I. Define production service post_merge resources.

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -207,7 +207,7 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push result success "first_push"
-            - name: "[first_deploy] X. Test: Test responses on demo app using Blackfire Player."
+            - name: "[first_deploy] 4. Test: Test responses on demo app using Blackfire Player."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   cmd=$(cat frontend/src/commands.json | jq -r ".first_deploy.user.get_url") 
@@ -230,12 +230,12 @@ jobs:
               run: |
                   ./utils/tests/activity_outcome.sh $STAGING_BRANCH environment.branch result success "environment_branch"
 
-            - name: "[environment_branch] X. Test: Test responses on demo app using Blackfire Player."
+            - name: "[environment_branch] 4. Test: Test responses on demo app using Blackfire Player."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   URL=$(upsun url --primary --pipe)
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=redis -vvv
-            - name: "[environment_branch] 9. Update staging environment name."
+            - name: "[environment_branch] 5. Update staging environment name."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   upsun environment:info title "Staging ($STAGING_BRANCH)" -e $STAGING_BRANCH
@@ -259,7 +259,7 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                 ./utils/tests/activity_outcome.sh $STAGING_BRANCH push result success "add_service"
-            - name: "[add_service_resources] X. Test: Test responses on demo app using Blackfire Player."
+            - name: "[add_service_resources] 4. Test: Test responses on demo app using Blackfire Player."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   URL=$(upsun url --primary --pipe)
@@ -282,11 +282,10 @@ jobs:
                 ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push result failure "merge"
                 
             ################################################################################################
-            # J. Define production service resources.
+            # I. Define production service post_merge resources.
             - name: "[prod_service_resources] 1. Set Redis' resources on production."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
-                  # upsun resources:set --size redis_persistent:0.1 --disk redis_persistent:512 -e $DEFAULT_BRANCH
                   cmd=$(cat frontend/src/commands.json | jq -r ".merge_production.test.resources_set") 
                   eval "$cmd"
             - name: "[prod_service_resources] 2. Test: The update environment resources activity should complete."
@@ -297,8 +296,28 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update result success "init_resources"
+            - name: "[prod_service_resources] 4. Test: Test responses on demo app using Blackfire Player."
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  URL=$(upsun url --primary --pipe)
+                  blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=complete -vvv
 
-            - name: "[prod_service_resources] X. Test: Test responses on demo app using Blackfire Player."
+            ################################################################################################
+            # J. Scale down to minimum resources
+            - name: "[scale] 1. Scale down to minimum resources for Redis"
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  cmd=$(cat frontend/src/commands.json | jq -r ".scale.test.resources_set") 
+                  eval "$cmd"
+            - name: "[scale] 2. Test: The update environment resources activity should complete."
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update state complete "init_resources"
+            - name: "[scale] 3. Test: The update environment resources activity should succeed."
+              working-directory: ${{ env.PROJECT_LOCALDIR }}
+              run: |
+                  ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update result success "init_resources"
+            - name: "[scale] 4. Test: Test responses on demo app using Blackfire Player."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   URL=$(upsun url --primary --pipe)

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -322,8 +322,9 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   git checkout $DEFAULT_BRANCH
-                  URL=$(upsun url --primary --pipe)
-                  blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=complete -vvv
+                  git branch
+                  URL=$(upsun url $DEFAULT_BRANCH -e --primary --pipe)
+                  blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=scale -vvv
 
             ################################################################################################
             # K. Clean up test project.

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -269,6 +269,7 @@ jobs:
             # H. Promote revision to production.
             - name: "[merge] 1. Merge staging into production."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
+              continue-on-error: true
               run: |
                   cmd=$(cat frontend/src/commands.json | jq -r ".merge_production.test.merge") 
                   eval "$cmd"

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -203,28 +203,12 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |    
                 ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push state complete "first_push"  
-            - name: "[first_deploy] 3. Test: The first deploy activity should fail."
-              working-directory: ${{ env.PROJECT_LOCALDIR }}
-              run: |
-                ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH push result failure "first_push"
-
-            ################################################################################################
-            # F. Set initial resources.
-            - name: "[init_resources] 1. Set initial resources."
-              working-directory: ${{ env.PROJECT_LOCALDIR }}
-              run: |
-                  cmd=$(cat frontend/src/commands.json | jq -r ".first_deploy.user.resources_set") 
-                  eval "$cmd"
-            - name: "[init_resources] 2. Test: The update environment resources activity should complete."
-              working-directory: ${{ env.PROJECT_LOCALDIR }}
-              run: |
-                  ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update state complete "init_resources"
-            - name: "[init_resources] 3. Test: The update environment resources activity should succeed."
+            - name: "[first_deploy] 3. Test: The update environment resources activity should succeed."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   ./utils/tests/activity_outcome.sh $DEFAULT_BRANCH environment.resources.update result success "init_resources"
             
-            - name: "[init_resources] X. Test: Test responses on demo app using Blackfire Player."
+            - name: "[first_deploy] X. Test: Test responses on demo app using Blackfire Player."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   cmd=$(cat frontend/src/commands.json | jq -r ".first_deploy.user.get_url") 
@@ -233,7 +217,7 @@ jobs:
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=branch -vvv
 
             ################################################################################################
-            # G. Create staging environment.
+            # F. Create staging environment.
             - name: "[environment_branch] 1. Create preview environment"
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -213,6 +213,7 @@ jobs:
                   cmd=$(cat frontend/src/commands.json | jq -r ".first_deploy.user.get_url") 
                   eval "$cmd"
                   URL=$(eval "$cmd --pipe")
+                  sleep 2
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=branch -vvv
 
             ################################################################################################
@@ -234,6 +235,7 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   URL=$(upsun url --primary --pipe)
+                  sleep 2
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=redis -vvv
             - name: "[environment_branch] 5. Update staging environment name."
               working-directory: ${{ env.PROJECT_LOCALDIR }}
@@ -263,6 +265,7 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   URL=$(upsun url --primary --pipe)
+                  sleep 2
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=merge-production -vvv
 
             ################################################################################################
@@ -301,6 +304,7 @@ jobs:
               working-directory: ${{ env.PROJECT_LOCALDIR }}
               run: |
                   URL=$(upsun url --primary --pipe)
+                  sleep 2
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=complete -vvv
 
             ################################################################################################
@@ -324,6 +328,7 @@ jobs:
                   git checkout $DEFAULT_BRANCH
                   git branch
                   URL=$(upsun url $DEFAULT_BRANCH -e --primary --pipe)
+                  sleep 2
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=scale -vvv
 
             ################################################################################################

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -327,7 +327,7 @@ jobs:
               run: |
                   git checkout $DEFAULT_BRANCH
                   git branch
-                  URL=$(upsun url $DEFAULT_BRANCH -e --primary --pipe)
+                  URL=$(upsun url -e $DEFAULT_BRANCH --primary --pipe)
                   sleep 2
                   blackfire-player run blackfire.yaml --endpoint="$URL" --variable step=scale -vvv
 

--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -68,11 +68,11 @@ applications:
 # # Step 3: Add a service. Uncomment this section.
 # ######################################################################################################################
 #         relationships:
-#              redis_session: "redis_persistent:redis"
+#             redis_session: "redis_service:redis"
 
 # services:
-#    redis_persistent:
-#        type: "redis-persistent:7.0"
+#     redis_service:
+#         type: "redis:7.0"
 # ######################################################################################################################
 # #add_service_end
     

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -5,6 +5,8 @@ import json
 
 bp = Blueprint('routes', __name__)
 
+service_relationship ="redis_session"
+
 API_PREFIX = '/api/v1'
 
 @bp.route(f'{API_PREFIX}/environment')
@@ -24,7 +26,7 @@ def getSessionStorageType():
     try:
         platform_relationships = json.loads(base64.b64decode(platform_relationships_data))
         
-        if 'redis_session' in platform_relationships:
+        if service_relationship in platform_relationships:
             return 'redis'
         else:
             return 'file'

--- a/blackfire.yaml
+++ b/blackfire.yaml
@@ -71,3 +71,7 @@ scenarios: |
             visit url("/api/v1/environment")
                 expect "redis" == json("session_storage")
                 expect "production" == json("type")
+        when "scale" == step 
+            visit url("/api/v1/environment")
+                expect "redis" == json("session_storage")
+                expect "production" == json("type")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -172,7 +172,6 @@ services:
                         <li className="mt-2 ml-6">Cloned the demo: <code className="ml-2 px-4">{commands.first_deploy.user.clone}</code></li>
                         <li className="mt-2 ml-6">Connected to Upsun: <code className="ml-2 px-4">{commands.first_deploy.user.set_remote} {PROJECT_ID}</code></li>
                         <li className="mt-2 ml-6">Pushed to Upsun: <code className="ml-2 px-4">{commands.first_deploy.user.push}</code></li>
-                        <li className="mt-2 ml-6">Defined deployment resources: <code className="ml-2 px-4">{commands.first_deploy.user.resources_set}</code></li>
                         <li className="mt-2 ml-6">Retrieved the deployed environment URL: <code className="ml-2 px-4">{commands.first_deploy.user.get_url}</code></li>
                       </ul>
                     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -338,6 +338,25 @@ services:
                       You've just experienced the power of Upsun's Git-based workflow to stage and deploy Redis seamlessly.
                     </p>
                     <p className="mb-2 mt-5">
+                      {/* <span>Upsun automatically allocated a set of default resources for each service in your project, but you can <strong>scale 
+                        those resources</strong> to whatever you need. For example, you can scale down the amount of resources on the
+                        Redis service container with the following command:
+                      </span> */}
+                      <span>You've used the Upsun CLI to merge a new service into production, and to match the resources you worked with in staging to that environment.
+                        From here, you can <strong>scale those resources</strong> to whatever you need. 
+                        For example, at this moment your production Redis service has 0.5 CPU. 
+                        You can scale down the amount of resources on the production Redis service container with the following command:
+                      </span>
+                      <CopyButton className="pl-1 inline-block w-full" copyText={commands.scale.user.resources_set}>
+                        <p className="mb-2 mt-2 code-block">
+                          <CodeBlock
+                            text={commands.scale.user.resources_set}
+                            showLineNumbers={false}
+                          />
+                        </p>
+                      </CopyButton>
+                    </p>
+                    <p className="mb-2 mt-5">
                       <span>Delete this project when ready using:</span>
                       <CodeExample copyText={commands.complete.user.delete_project} codeExampleText={commands.complete.user.delete_project}/>
                     </p>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,11 +51,11 @@ function App() {
 # Step 3: Add a service. Uncomment this section.
 ###############################################################
         relationships:
-             redis_session: "redis_service:redis"
+            redis_session: "redis_service:redis"
 
 services:
-   redis_service:
-       type: "redis:7.0"
+    redis_service:
+        type: "redis:7.0"
 ###############################################################`
 
   useEffect(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,11 +51,11 @@ function App() {
 # Step 3: Add a service. Uncomment this section.
 ###############################################################
         relationships:
-            redis_session: "redis_persistent:redis"
-      
+             redis_session: "redis_service:redis"
+
 services:
-    redis_persistent:
-        type: "redis-persistent:7.0"
+   redis_service:
+       type: "redis:7.0"
 ###############################################################`
 
   useEffect(() => {
@@ -262,12 +262,6 @@ services:
                         <p className="mb-2 mt-2">
                           <span>Push</span>
                           <CodeExample copyText={commands.redis.user.push} codeExampleText={commands.redis.user.push}/>
-                        </p>
-                      </li>
-                      <li>
-                        <p className="mb-2 mt-2">
-                          <span>Allocate Redis resources</span>
-                          <CodeExample wrapLines copyText={commands.redis.user.resources_set} codeExampleText={commands.redis.user.resources_set}/>
                         </p>
                       </li>
                       <li>

--- a/frontend/src/commands.json
+++ b/frontend/src/commands.json
@@ -39,7 +39,7 @@
     "merge_production": {
         "user": {
             "merge": "upsun merge staging",
-            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1 \\\n\t-e main",
+            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.5 \\\n\t-e main",
             "get_url": "upsun url --primary -e main"
         },
         "test": {
@@ -47,7 +47,14 @@
             "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1"
         }
     },
-    "scale": false,
+    "scale": {
+        "user": {
+            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1 \\\n\t-e main"
+        },
+        "test": {
+            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1"
+        }
+    },
     "complete": {
         "user": {
             "delete_project": "upsun project:delete"

--- a/frontend/src/commands.json
+++ b/frontend/src/commands.json
@@ -43,7 +43,7 @@
             "get_url": "upsun url --primary -e main"
         },
         "test": {
-            "merge": "git checkout $DEFAULT_BRANCH && git merge $STAGING_BRANCH && git push --force upsun $DEFAULT_BRANCH",
+            "merge": "upsun merge staging",
             "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1"
         }
     },

--- a/frontend/src/commands.json
+++ b/frontend/src/commands.json
@@ -43,7 +43,7 @@
             "get_url": "upsun url --primary -e main"
         },
         "test": {
-            "merge": "upsun merge staging",
+            "merge": "upsun merge $STAGING_BRANCH",
             "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1"
         }
     },

--- a/frontend/src/commands.json
+++ b/frontend/src/commands.json
@@ -44,7 +44,7 @@
         },
         "test": {
             "merge": "upsun merge $STAGING_BRANCH",
-            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1"
+            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.5 \\\n\t-e $DEFAULT_BRANCH"
         }
     },
     "scale": {
@@ -52,7 +52,7 @@
             "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1 \\\n\t-e main"
         },
         "test": {
-            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1"
+            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1 \\\n\t-e $DEFAULT_BRANCH"
         }
     },
     "complete": {

--- a/frontend/src/commands.json
+++ b/frontend/src/commands.json
@@ -10,7 +10,6 @@
             "clone": "git clone git@github.com:platformsh/demo-project.git",
             "set_remote": "upsun project:set-remote",
             "push": "upsun push",
-            "resources_set": "upsun resources:set --size '*:0.1'",
             "get_url": "upsun url --primary"
         },
         "test": {
@@ -32,7 +31,6 @@
         "user": {
             "commit": "git commit -am \"Create a Redis service.\"",
             "push": "upsun push",
-            "resources_set": "upsun resources:set \\\n\t--size redis_persistent:0.1 \\\n\t--disk redis_persistent:512"
         },
         "test": {
             "push": "git push --force upsun $STAGING_BRANCH"
@@ -41,12 +39,12 @@
     "merge_production": {
         "user": {
             "merge": "upsun merge staging",
-            "resources_set": "upsun resources:set \\\n\t--size redis_persistent:0.1 \\\n\t--disk redis_persistent:512 \\\n\t-e main",
+            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1 \\\n\t-e main",
             "get_url": "upsun url --primary -e main"
         },
         "test": {
             "merge": "git checkout $DEFAULT_BRANCH && git merge $STAGING_BRANCH && git push --force upsun $DEFAULT_BRANCH",
-            "resources_set": "upsun resources:set \\\n\t--size redis_persistent:0.1 \\\n\t--disk redis_persistent:512"
+            "resources_set": "upsun resources:set \\\n\t--size redis_service:0.1"
         }
     },
     "scale": false,

--- a/frontend/src/commands.json
+++ b/frontend/src/commands.json
@@ -30,7 +30,7 @@
     "redis": {
         "user": {
             "commit": "git commit -am \"Create a Redis service.\"",
-            "push": "upsun push",
+            "push": "upsun push"
         },
         "test": {
             "push": "git push --force upsun $STAGING_BRANCH"

--- a/readme.md
+++ b/readme.md
@@ -91,22 +91,7 @@ If for some reason you close your browser and lose your place, however, you can 
     upsun push -y --set-remote PROJECT_ID
     ```
 
-4. Set resources
-
-    > [!NOTE]
-    > You can determine if you have already defined resources for the demo project with the command `upsun activity:list --type environment.resources.update --result=success`.
-    > If you've successfully defined resources, there will be an entry in the table that says **Your Name updated resource allocation on Main**.
-    >
-    > If you see a successful `environment.resources.update` activity, move on to step 5.
-
-    You first push for the demo project will fail because Upsun does not yet know what resources should be deployed. 
-    Run the command below to complete the deployment.
-
-    ```bash
-    upsun resources:set --size '*:1'
-    ```
-
-5. View the environment
+4. View the environment
 
     You should be all caught up to resume the demo at this point. 
     Run `upsun url --primary` to view the environment, and visit https://console.upsun.com/projects/PROJECT_ID to view the project.


### PR DESCRIPTION
Git 24 introduces default resources, which remove `resources:set` requirements and change the path slightly. Namely: 

- default resources are set for each push
- resources settings of a child environment are "inherited" by a parent

Closes https://github.com/platformsh/demo-project/issues/60

Closes https://github.com/platformsh/demo-project/pull/72

**Not included in this PR**

- it is still required that you set a new service's resources post-merge
- the CLI does not yet support `minimum`/`default` `resource:set` strategies