### PR TITLE
Suppress npm warnings in production

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -23,7 +23,7 @@ applications:
         hooks:
             build: |
                 set -eux
-                npm install
+                npm install --silent
                 export REACT_APP_PROJECT_ID=$PLATFORM_PROJECT
                 npm run build
 


### PR DESCRIPTION
Adds `--silent` to production installs of the frontend to quiet warnings.